### PR TITLE
fix: undefined check in banner plugin

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "git.ignoreLimitWarning": true
+  "git.ignoreLimitWarning": true,
+  "editor.lineNumbers": "on"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glyf",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "glyf",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
         "@radix-ui/react-icons": "^1.2.0",

--- a/src/components/glyf-editor/plugins/banner/BannerPlugin.tsx
+++ b/src/components/glyf-editor/plugins/banner/BannerPlugin.tsx
@@ -45,8 +45,8 @@ export class BannerNode extends ElementNode {
 
   updateDOM(prevNode: HTMLElement, domNode: HTMLElement): boolean {
     return (
-      prevNode.style.backgroundColor !== domNode.style.backgroundColor ||
-      prevNode.style.borderLeft !== domNode.style.borderLeft
+      prevNode.style?.backgroundColor !== domNode.style.backgroundColor ||
+      prevNode.style?.borderLeft !== domNode.style.borderLeft
     );
   }
 


### PR DESCRIPTION
This pull request checks for `undefined` in `updateDom` methhod in `BannerPlugin.tsx` file so that error of reading `backgroundColor of undefined` should be gone from browser console.