### PR TITLE
feat: `onChange` callback

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "git.ignoreLimitWarning": true
+  "git.ignoreLimitWarning": true,
+  "editor.lineNumbers": "on"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glyf",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "glyf",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
         "@radix-ui/react-icons": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.19.6",
+        "@lexical/html": "^0.8.0",
         "@lexical/react": "^0.8.0",
         "@storybook/addon-actions": "^6.5.13",
         "@storybook/addon-essentials": "^6.5.13",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.19.6",
+    "@lexical/html": "^0.8.0",
     "@lexical/react": "^0.8.0",
     "@storybook/addon-actions": "^6.5.13",
     "@storybook/addon-essentials": "^6.5.13",

--- a/src/components/glyf-editor/Editor.tsx
+++ b/src/components/glyf-editor/Editor.tsx
@@ -1,15 +1,17 @@
 import * as React from 'react';
-import './styles.css';
+import { ListItemNode, ListNode } from '@lexical/list';
 import { LexicalComposer } from '@lexical/react/LexicalComposer';
 import { ContentEditable } from '@lexical/react/LexicalContentEditable';
-import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin';
 import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary';
+import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin';
+import { ListPlugin } from '@lexical/react/LexicalListPlugin';
 import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
 import { HeadingNode } from '@lexical/rich-text';
-import { ListPlugin } from '@lexical/react/LexicalListPlugin';
-import { ListNode, ListItemNode } from '@lexical/list';
+import { type EditorState } from 'lexical';
 import { ToolbarPlugin } from '../glyf-toolbar/Toolbar';
-import { BannerPlugin, BannerNode } from './plugins/banner/BannerPlugin';
+import { BannerNode, BannerPlugin } from './plugins/banner/BannerPlugin';
+import './styles.css';
+import OnChangePlugin from './plugins/on-change/OnChangePlugin';
 
 const theme = {
   heading: {
@@ -31,7 +33,11 @@ function onError(error: Error): void {
   console.error(error);
 }
 
-export default function Editor(): JSX.Element {
+interface EditorProps {
+  onChange: (editorState: EditorState, htmlContent: string) => void;
+}
+
+export default function Editor({ onChange }: EditorProps): JSX.Element {
   const initialConfig = {
     namespace: 'MyEditor',
     theme,
@@ -41,6 +47,7 @@ export default function Editor(): JSX.Element {
 
   return (
     <LexicalComposer initialConfig={initialConfig}>
+      <OnChangePlugin onChange={onChange} />
       <ToolbarPlugin />
       <BannerPlugin />
       <ListPlugin />

--- a/src/components/glyf-editor/plugins/banner/BannerPlugin.tsx
+++ b/src/components/glyf-editor/plugins/banner/BannerPlugin.tsx
@@ -45,8 +45,8 @@ export class BannerNode extends ElementNode {
 
   updateDOM(prevNode: HTMLElement, domNode: HTMLElement): boolean {
     return (
-      prevNode.style.backgroundColor !== domNode.style.backgroundColor ||
-      prevNode.style.borderLeft !== domNode.style.borderLeft
+      prevNode.style?.backgroundColor !== domNode.style.backgroundColor ||
+      prevNode.style?.borderLeft !== domNode.style.borderLeft
     );
   }
 

--- a/src/components/glyf-editor/plugins/on-change/OnChangePlugin.tsx
+++ b/src/components/glyf-editor/plugins/on-change/OnChangePlugin.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { type EditorState } from 'lexical';
+import { $generateHtmlFromNodes } from '@lexical/html';
+
+interface CustomOnChangeProps {
+  onChange: (editorState: EditorState, htmlContent: string) => void;
+}
+
+export default function OnChangePlugin({ onChange }: CustomOnChangeProps): null {
+  const [editor] = useLexicalComposerContext();
+
+  React.useEffect(() => {
+    return editor.registerUpdateListener(({ editorState }) => {
+      editorState.read(() => {
+        onChange(editorState, $generateHtmlFromNodes(editor));
+      });
+    });
+  }, [editor, onChange]);
+
+  return null;
+}

--- a/src/components/glyf-editor/styles.css
+++ b/src/components/glyf-editor/styles.css
@@ -1,62 +1,66 @@
 .contentEditable {
-    height: 300px;
-    width: 100%;
-    padding: 0 8px;
-    border: 1px solid #fff;
-    border-radius: 4px;
-    overflow-y: scroll;
-    outline: none;
+  height: 300px;
+  width: 100%;
+  padding: 0 8px;
+  border: 1px solid;
+  border-radius: 4px;
+  overflow-y: scroll;
+  outline: none;
+}
+
+.contentEditable:focus {
+  border: 1.5px solid;
 }
 
 .placeholder {
-    position: absolute;
-    top: 62px;
-    padding-left: 8px;
-    pointer-events: none;
+  position: absolute;
+  top: 62px;
+  padding-left: 8px;
+  pointer-events: none;
 }
 
 .toolbar-wrapper {
-    display: flex;
+  display: flex;
 }
 
 .glyf-editor-bold {
-    font-weight: 600;
+  font-weight: 600;
 }
 
 .glyf-editor-italic {
-    font-style: italic;
+  font-style: italic;
 }
 
 .glyf-editor-underline {
-    text-decoration: underline;
+  text-decoration: underline;
 }
 
 .glyf-editor-strikethrough {
-    text-decoration: line-through;
+  text-decoration: line-through;
 }
 
 .glyf-editor-underlineStrikethrough {
-    text-decoration: underline line-through;
+  text-decoration: underline line-through;
 }
 
 .glyf-editor-h1 {
-    font-size: 48px;
-    text-decoration: underline;
-    font-weight: bold;
+  font-size: 48px;
+  text-decoration: underline;
+  font-weight: bold;
 }
 
 .glyf-editor-h2 {
-    font-size: 40px;
-    font-weight: bold;
+  font-size: 40px;
+  font-weight: bold;
 }
 
 .glyf-editor-h3 {
-    font-size: 24px;
-    font-weight: normal;
-    text-transform: uppercase;
+  font-size: 24px;
+  font-weight: normal;
+  text-transform: uppercase;
 }
 
 .glyf-editor-banner {
-    margin: 8px 0;
-    padding: 8px;
+  margin: 8px 0;
+  padding: 8px;
 }

--- a/src/components/glyf-toolbar/styles.css
+++ b/src/components/glyf-toolbar/styles.css
@@ -1,5 +1,5 @@
 button {
-    all: unset;
+  all: unset;
 }
 
 .toolbarRoot {
@@ -34,9 +34,7 @@ button {
 .toolbarButton {
   padding-left: 10px;
   padding-right: 10px;
-  color: white;
   cursor: pointer;
 }
 .toolbarButton:hover {
-  color: white;
 }

--- a/src/playground/App.tsx
+++ b/src/playground/App.tsx
@@ -7,7 +7,11 @@ function App(): JSX.Element {
     <div className="App">
       <h1 className="editorHeading">Glyf Editor</h1>
       <div className="editorWrapper">
-        <GlyfEditor />
+        <GlyfEditor
+          onChange={(editorState, htmlContent) => {
+            console.log(htmlContent);
+          }}
+        />
       </div>
     </div>
   );

--- a/src/playground/index.css
+++ b/src/playground/index.css
@@ -1,7 +1,5 @@
 :root {
   font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
This Pull request adds `onChange` callback function to the `Editor` instance so developers can use this callback to have the latest `editorState` or `htmlContent`. `onChange` callback provides two arguments: first one is the latest editor state of type `EditorState` and the second is the html content of editor which has type `string`.

NOTE: It also removes dark theme and migrate to the light theme as default.
NOTE: Maybe adding some default themes is also a good approach for default theme.